### PR TITLE
adds ability to define metrics for display

### DIFF
--- a/app/Console/Commands/RepoStats.php
+++ b/app/Console/Commands/RepoStats.php
@@ -20,6 +20,7 @@ class RepoStats extends Command
         {repo : Repository path}
         {--date-from= : Date since}
         {--date-to= : Date until}
+        {--metrics= : Comma separated metric names to be displayed}
     ';
 
     /**
@@ -57,6 +58,7 @@ class RepoStats extends Command
         ($dateFrom && $dateTo)
             ? $gitLogRunner->setDateRange($dateFrom, $dateTo)
             : $gitLogRunner->setDateRangeLastMonth();
+        $metrics = $this->option('metrics');
 
         $commits = $gitLogRunner->run();
 
@@ -66,8 +68,9 @@ class RepoStats extends Command
             $commit->save();
         }
 
-        $parser = new Parser;
-        $parser->parse();
+        $parser = new Parser();
+        $parser->setMetrics($metrics)
+            ->parse();
         $this->table($parser->getHeader(), $parser->getData());
     }
 }

--- a/app/Models/Parser.php
+++ b/app/Models/Parser.php
@@ -8,77 +8,100 @@ class Parser
 {
     protected $_header;
     protected $_data;
+    protected $_metrics;
 
     public function parse()
     {
         $data = [];
 
-        $mapNewAuthorsToSelf = DB::insert("insert into AuthorMap(author,map) select distinct c.author, c.author from `Commit` c left join AuthorMap m on m.author=c.author where m.author is null");
+        DB::insert("insert into AuthorMap(author,map) select distinct c.author, c.author from `Commit` c left join AuthorMap m on m.author=c.author where m.author is null");
 
         $mapResults = DB::select('select distinct map from AuthorMap');
-        $maps = [];
         foreach ($mapResults as $key => $mapResult) {
-            $maps[] = $mapResult->map;
             $data[$mapResult->map] = [
-                'team' => $mapResult->map,
-                'ALL' => 0,
-                'Direct' => 0,
-                'Self Merges' => 0,
-                'Tracked' => 0,
-                'Tracked %' => 0,
-                'PR %' => 0,
-                'Reverts' => 0
+                'team' => $mapResult->map
             ];
         }
 
         $data['TOTAL'] = [
             'team' => 'TOTAL',
-            'ALL' => 0,
-            'Direct' => 0,
-            'Self Merges' => 0,
-            'Tracked' => 0,
-            'Tracked %' => 0,
-            'PR %' => 0,
-            'Reverts' => 0
+            'ALL' => 0
         ];
+        $this->_header = ['team', 'ALL'];
 
-        $allCommits = DB::select('select m.map, count(*) as cnt from `Commit` c left join AuthorMap m on c.author = m.author group by m.map;');
-        $directCommits = DB::select('select m.map, count(*) as cnt from `Commit` c left join AuthorMap m on c.author = m.author where c.mergeCommit is null group by m.map;');
-        $trackedCommits = DB::select('select m.map, count(*) as cnt from `Commit` c left join AuthorMap m on c.author = m.author where c.tracked=1 group by m.map;');
-        $selfMergesCommits = DB::select('select m.map, count(*) as cnt from `Commit` c left join AuthorMap m on c.author = m.author where c.selfMerged=1 group by m.map;');
-        $revertCommits = DB::select('select m.map, count(*) as cnt from `Commit` c left join AuthorMap m on c.author = m.author where c.revert = 1 group by m.map;');
-
+        $allCommits = DB::select('select m.map, count(c.id) as cnt from AuthorMap m left join `Commit` c on c.author = m.author group by m.map;');
         foreach ($allCommits as $key => $row) {
             $data[$row->map]['ALL'] = $row->cnt;
             $data['TOTAL']['ALL'] += $row->cnt;
         }
 
-        foreach ($directCommits as $key => $row) {
-            $data[$row->map]['Direct'] = $row->cnt;
-            $data['TOTAL']['Direct'] += $row->cnt;
+        if (!$this->_metrics || in_array('direct', $this->_metrics)) {
+            $this->_header[] = 'Direct';
+            $data['TOTAL']['Direct'] = 0;
+
+            $directCommits = DB::select('select m.map, count(c.id) as cnt from AuthorMap m left join `Commit` c on c.author = m.author and c.mergeCommit is null group by m.map;');
+            foreach ($directCommits as $key => $row) {
+                $data[$row->map]['Direct'] = $row->cnt;
+                $data['TOTAL']['Direct'] += $row->cnt;
+            }
         }
 
-        foreach ($trackedCommits as $key => $row) {
-            $data[$row->map]['Tracked'] = $row->cnt;
-            $data['TOTAL']['Tracked'] += $row->cnt;
+        if (!$this->_metrics || in_array('self-merges', $this->_metrics)) {
+            $this->_header[] = 'Self Merges';
+            $data['TOTAL']['Self Merges'] = 0;
+
+            $selfMergesCommits = DB::select('select m.map, count(c.id) as cnt from AuthorMap m left join `Commit` c on c.author = m.author and c.selfMerged = 1 group by m.map;');
+            foreach ($selfMergesCommits as $key => $row) {
+                $data[$row->map]['Self Merges'] = $row->cnt;
+                $data['TOTAL']['Self Merges'] += $row->cnt;
+            }
         }
 
-        foreach ($selfMergesCommits as $key => $row) {
-            $data[$row->map]['Self Merges'] = $row->cnt;
-            $data['TOTAL']['Self Merges'] += $row->cnt;
+        if (!$this->_metrics || in_array('tracked', $this->_metrics)) {
+            $this->_header[] = 'Tracked';
+            $this->_header[] = 'Tracked %';
+            $data['TOTAL']['Tracked'] = 0;
+            $data['TOTAL']['Tracked %'] = 0;
+
+            $trackedCommits = DB::select('select m.map, count(c.id) as cnt from AuthorMap m left join `Commit` c on c.author = m.author and c.tracked = 1 group by m.map;');
+            foreach ($trackedCommits as $key => $row) {
+                $data[$row->map]['Tracked'] = $row->cnt;
+                $data['TOTAL']['Tracked'] += $row->cnt;
+            }
+
+            foreach ($data as $key => $value) {
+                $data[$key]['Tracked %'] = ($value['ALL'] > 0) ? number_format(100 * ($value['Tracked'] / $value['ALL']), 2) : 'N/A';
+            }
         }
 
-        foreach ($revertCommits as $key => $row) {
-            $data[$row->map]['Reverts'] = $row->cnt;
-            $data['TOTAL']['Reverts'] += $row->cnt;
+        if (!$this->_metrics || in_array('pull-requests', $this->_metrics)) {
+            $this->_header[] = 'PRs';
+            $this->_header[] = 'PRs %';
+            $data['TOTAL']['PRs'] = 0;
+            $data['TOTAL']['PRs %'] = 0;
+
+            $merges = DB::select('select m.map, count(c.id) as cnt from AuthorMap m left join `Commit` c on c.author = m.author and not c.mergeCommit is null group by m.map;');
+            foreach ($merges as $key => $row) {
+                $data[$row->map]['PRs'] = $row->cnt;
+                $data['TOTAL']['PRs'] += $row->cnt;
+            }
+
+            foreach ($data as $key => $value) {
+                $data[$key]['PRs %'] = ($value['ALL'] > 0) ? number_format(100 * ($value['PRs'] / $value['ALL']), 2) : 'N/A';
+            }
         }
 
-        foreach ($data as $key => $value) {
-            $data[$key]['Tracked %'] = ($value['ALL'] > 0) ? number_format(100*$value['Tracked']/$value['ALL'], 2) : 'N/A';
-            $data[$key]['PR %'] = ($value['ALL'] > 0) ? number_format(100*($value['ALL']-$value['Direct']-$value['Self Merges'])/$value['ALL'], 2) : 'N/A';
+        if (!$this->_metrics || in_array('reverts', $this->_metrics)) {
+            $this->_header[] = 'Reverts';
+            $data['TOTAL']['Reverts'] = 0;
+
+            $revertCommits = DB::select('select m.map, count(c.id) as cnt from AuthorMap m left join `Commit` c on c.author = m.author and c.revert = 1 group by m.map;');
+            foreach ($revertCommits as $key => $row) {
+                $data[$row->map]['Reverts'] = $row->cnt;
+                $data['TOTAL']['Reverts'] += $row->cnt;
+            }
         }
 
-        $this->_header = ['team','ALL','Direct','Self Merges','Tracked','Tracked %','PR %','Reverts'];
         $this->_data = $data;
         return;
     }
@@ -91,5 +114,11 @@ class Parser
     public function getData()
     {
         return $this->_data;
+    }
+
+    public function setMetrics($metrics)
+    {
+        $this->_metrics = $metrics ? explode(',', $metrics) : [];
+        return $this;
     }
 }

--- a/tests/Functional/RepoStatsTest.php
+++ b/tests/Functional/RepoStatsTest.php
@@ -28,12 +28,45 @@ class RepoStatsTest extends TestCase
         }
 
         $expectedOutput = <<<OUTPUT
-+----------------------------+-----+--------+-------------+---------+-----------+------+---------+
-| team                       | ALL | Direct | Self Merges | Tracked | Tracked % | PR % | Reverts |
-+----------------------------+-----+--------+-------------+---------+-----------+------+---------+
-| dbaltas@travelplanet24.com | 1   | 1      | 0           | 0       | 0.00      | 0.00 | 0       |
-| TOTAL                      | 1   | 1      | 0           | 0       | 0.00      | 0.00 | 0       |
-+----------------------------+-----+--------+-------------+---------+-----------+------+---------+
++----------------------------+-----+--------+-------------+---------+-----------+-----+-------+---------+
+| team                       | ALL | Direct | Self Merges | Tracked | Tracked % | PRs | PRs % | Reverts |
++----------------------------+-----+--------+-------------+---------+-----------+-----+-------+---------+
+| dbaltas@travelplanet24.com | 1   | 1      | 0           | 0       | 0.00      | 0   | 0.00  | 0       |
+| TOTAL                      | 1   | 1      | 0           | 0       | 0.00      | 0   | 0.00  | 0       |
++----------------------------+-----+--------+-------------+---------+-----------+-----+-------+---------+
+
+OUTPUT;
+        $this->assertEquals($expectedOutput, $process->getOutput());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testRepoStatsWithSpecificMetricsOnSameRepo()
+    {
+        $this->createDatabase();
+
+        $process = new Process($this->getMigrateCommand());
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            $this->fail("Migrate failed" . $process->getOutput());
+        }
+
+        $process = new Process($this->getCommandWithMetricsArgument());
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            $this->fail("command failed" . $process->getOutput());
+        }
+
+        $expectedOutput = <<<OUTPUT
++----------------------------+-----+--------+---------+-----------+
+| team                       | ALL | Direct | Tracked | Tracked % |
++----------------------------+-----+--------+---------+-----------+
+| dbaltas@travelplanet24.com | 1   | 1      | 0       | 0.00      |
+| TOTAL                      | 1   | 1      | 0       | 0.00      |
++----------------------------+-----+--------+---------+-----------+
 
 OUTPUT;
         $this->assertEquals($expectedOutput, $process->getOutput());
@@ -41,10 +74,28 @@ OUTPUT;
 
     /**
      * @param string|null $memoryLimit, if null
+     * @return string
      */
     protected function getCommand($memoryLimit = null)
     {
-        $cmd = sprintf("./artisan repo:stats . --date-from 'May 1 2017'  --date-to 'JUN 1 2017'");
+        $cmd = sprintf("./artisan repo:stats . --date-from 'May 1 2017' --date-to 'JUN 1 2017'");
+
+        if ($memoryLimit) {
+            $cmd = "php -d memory_limit=$memoryLimit " . $cmd;
+        }
+
+        $cmd = 'APP_ENV=functional-test ' . $cmd;
+
+        return $cmd;
+    }
+
+    /**
+     * @param string|null $memoryLimit, if null
+     * @return string
+     */
+    protected function getCommandWithMetricsArgument($memoryLimit = null)
+    {
+        $cmd = sprintf("./artisan repo:stats --date-from 'May 1 2017' --date-to 'JUN 1 2017' --metrics=direct,tracked .");
 
         if ($memoryLimit) {
             $cmd = "php -d memory_limit=$memoryLimit " . $cmd;


### PR DESCRIPTION
Adds a --metrics to define the metrics to be shown.
I've put:

- direct,
- tracked,
- self-merges,
- pull-requests

PRs and tracked also dump their percentages too.

Also, added a PRs count to the results.
Initially I needed it to change the way the PR % was calculated. It required the self-merges to be calculated too which would be not selected by the user to be shown.

Thought that may be a useful metric too, so I left it.
I can remove it if it seems redundant.