### PR TITLE
Split models to entities and services

### DIFF
--- a/app/Console/Commands/RepoStats.php
+++ b/app/Console/Commands/RepoStats.php
@@ -73,10 +73,10 @@ class RepoStats extends Command
             $commit->save();
         }
 
-        $parser = new ReporterService();
+        $reporter = new ReporterService();
         $metrics = $this->option('metrics');
-        $parser->setMetrics($metrics)
+        $reporter->setMetrics($metrics)
             ->prepare();
-        $this->table($parser->getHeader(), $parser->getData());
+        $this->table($reporter->getHeader(), $reporter->getData());
     }
 }

--- a/app/Console/Commands/RepoStats.php
+++ b/app/Console/Commands/RepoStats.php
@@ -3,8 +3,9 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
-use App\Models\GitLogRunner;
-use App\Models\Parser;
+
+use App\Services\ParserService;
+use App\Services\ReporterService;
 use App\Models\Commit;
 use App\Plugins\GitLogPlugin;
 
@@ -52,21 +53,19 @@ class RepoStats extends Command
         $plugin = new GitLogPlugin([
             'path' => $repo
         ]);
-        $gitLogRunner = new GitLogRunner($plugin);
+        $parser = new ParserService($plugin);
 
         $dateFrom = $this->option('date-from');
         $dateTo = $this->option('date-to');
         try {
             ($dateFrom && $dateTo)
-                ? $gitLogRunner->setDateRange($dateFrom, $dateTo)
-                : $gitLogRunner->setDefaultDateRange();
+                ? $parser->setDateRange($dateFrom, $dateTo)
+                : $parser->setDefaultDateRange();
         } catch (\Exception $ex) {
             $this->line('Invalid date given.');
             exit(1);
         }
-        $metrics = $this->option('metrics');
-
-        $commits = $gitLogRunner->run();
+        $commits = $parser->parse();
 
         Commit::truncate();
         foreach ($commits as $key => $commitAttributes) {
@@ -74,9 +73,10 @@ class RepoStats extends Command
             $commit->save();
         }
 
-        $parser = new Parser();
+        $parser = new ReporterService();
+        $metrics = $this->option('metrics');
         $parser->setMetrics($metrics)
-            ->parse();
+            ->prepare();
         $this->table($parser->getHeader(), $parser->getData());
     }
 }

--- a/app/Services/ParserService.php
+++ b/app/Services/ParserService.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Models;
+namespace App\Services;
 
 use App\Plugins\Plugin;
 
-class GitLogRunner
+class ParserService
 {
     protected $_dateFrom;
     protected $_dateTo;
@@ -42,7 +42,7 @@ class GitLogRunner
         $this->_dateTo = new \DateTime($dateTo);
     }
 
-    public function run()
+    public function parse()
     {
         if (!$this->_dateFrom || !$this->_dateTo) {
             throw new \Exception('You need to define a date range');

--- a/app/Services/ReporterService.php
+++ b/app/Services/ReporterService.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace App\Models;
+namespace App\Services;
 
 use Illuminate\Support\Facades\DB;
 
-class Parser
+class ReporterService
 {
     protected $_header;
     protected $_data;
     protected $_metrics;
 
-    public function parse()
+    public function prepare()
     {
         $data = [];
 


### PR DESCRIPTION
This is just a separation of models to database models (entities) and services, those having more operational role.

At the same time made renamed two of the services

- app/Models/GitLogRunner.php -> app/Services/ParserService.php
  Maybe should have been renamed earlier (gitLog is now a "plugin" https://github.com/dbaltas/commit-sniffer/pull/9 and this is more generic now). Named it "parser" as it parses the commit messages.

- app/Models/Parser.php -> app/Services/ReporterService.php
  Named it "reporter" as it reads from the database the commits, categorizes them and prepares the data for the output. Not that nice name, but coulnd't think of another.

@dbaltas naming is not final, we can change it if you prefer other names.